### PR TITLE
Fix README hyperlink formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Desenvolvido especialmente para a loja **Amigos Móveis Planejados**.
 ## Dúvidas ou melhorias?
 
 Este sistema foi feito para facilitar a gestão do seu negócio.  
-Se quiser mais funcionalidades (assinatura digital, WhatsApp, impressão, Pix, relatórios, backup, envio para e-mail), acesse o sistema clicando no link [link do site).
+Se quiser mais funcionalidades (assinatura digital, WhatsApp, impressão, Pix, relatórios, backup, envio para e-mail), acesse o sistema clicando no [site oficial](https://exemplo.com).
 
 ---
 


### PR DESCRIPTION
## Summary
- fix broken link syntax in README with standard Markdown link

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b0029b2088322bf4af3de5a419124