### PR TITLE
Implement client budget detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Você pode testar a aplicação online através do [GitHub Pages](https://joaona
   - **orcamentos/** — Domínio de orçamentos
     - **novo-orcamento.html** — Formulário para criação de orçamentos
     - **lista-orcamento.html** — Listagem e gestão de orçamentos existentes
+    - **orcamento/** — Subdomínio para visualizar o orçamento de um cliente
+      - **index.html** — Página com os detalhes do orçamento
+      - **orcamento.js** — Script do orçamento individual
     - **novo-orcamento.js** — Rotinas para criar e editar orçamentos
     - **lista-orcamento.js** — Ações da listagem de orçamentos
     - **orcamentos.css** — Estilos específicos do domínio

--- a/domains/orcamentos/lista-orcamento.js
+++ b/domains/orcamentos/lista-orcamento.js
@@ -33,6 +33,7 @@ function atualizarListaOrcamento() {
         <button class="btn-edit" onclick="editarOrcamento(${orc.idx})">Editar</button>
         <button class="btn-delete" onclick="removerOrcamento(${orc.idx})">Remover</button>
         <button class="btn-share" onclick="compartilharOrcamento(${orc.idx})">Compartilhar</button>
+        <button class="btn-view" onclick="verOrcamento(${orc.idx})">Ver</button>
       </div>
     `;
     ul.appendChild(li);
@@ -89,6 +90,10 @@ Agradecemos pela preferência!
   } else {
     prompt("Copie a nota eletrônica:", recibo);
   }
+}
+
+function verOrcamento(idx) {
+  window.location.href = `orcamento/index.html?idx=${idx}`;
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/domains/orcamentos/orcamento/index.html
+++ b/domains/orcamentos/orcamento/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Detalhe do Orçamento - Amigos Móveis Planejados</title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <link rel="stylesheet" href="../orcamentos.css">
+</head>
+<body>
+  <div class="header">
+    <div class="header-logo capitalize">Amigos Móveis Planejados</div>
+    <div class="header-desc">Gestão fácil de clientes e orçamentos<br>Móveis sob medida com confiança.</div>
+  </div>
+  <div class="container">
+    <div class="card" id="orcamento-cliente">
+      <h2>Orçamento do Cliente</h2>
+      <div id="orcamento-dados"></div>
+      <button class="form-btn" style="background:#fbbf24;color:#1e293b" onclick="window.history.back()">Voltar</button>
+    </div>
+  </div>
+  <script src="../../../script.js"></script>
+  <script src="orcamento.js"></script>
+  <footer style="text-align:center;font-size:.96em;padding:15px 7px 11px 7px;color:#6c584c; background:#f9fafb;">
+    Sistema desenvolvido por <b class="capitalize">João & Bruno</b>
+  </footer>
+</body>
+</html>

--- a/domains/orcamentos/orcamento/orcamento.js
+++ b/domains/orcamentos/orcamento/orcamento.js
@@ -1,0 +1,30 @@
+function obterParametro(nome) {
+  const url = new URL(window.location.href);
+  return url.searchParams.get(nome);
+}
+
+function exibirOrcamento() {
+  const idx = obterParametro('idx');
+  if (idx === null) {
+    document.getElementById('orcamento-dados').textContent = 'Orçamento não encontrado.';
+    return;
+  }
+  const orc = orcamentos[idx];
+  if (!orc) {
+    document.getElementById('orcamento-dados').textContent = 'Orçamento não encontrado.';
+    return;
+  }
+  const div = document.getElementById('orcamento-dados');
+  div.innerHTML = `
+    <b class="capitalize">${orc.cliente}</b><br>
+    CPF: <span style="font-size:.97em">${orc.cpf}</span><br>
+    Tel: <span style="font-size:.97em">${orc.telefone || ''}</span><br>
+    <span style="font-size:.96em;color:#777;" class="capitalize">${orc.endereco || ''}</span>
+    <ul style="padding-left:17px;margin:4px 0 5px 0;">
+      ${orc.itens.map(it=>`<li class="capitalize">${it.descricao} - <span>${formatarReal(it.valor)}</span></li>`).join('')}
+    </ul>
+    <b>Total: ${formatarReal(orc.total)}</b>
+  `;
+}
+
+document.addEventListener('DOMContentLoaded', exibirOrcamento);

--- a/script.js
+++ b/script.js
@@ -54,12 +54,14 @@ if (typeof showSection === "function") oldShowSection = showSection;
 showSection = function (id) {
   if (typeof oldShowSection === "function") oldShowSection(id);
 
-  const basePath = location.pathname.includes('/domains/') ? '../../' : './';
+  const depth = location.pathname.split('/').filter(Boolean).length - 1;
+  const basePath = depth ? '../'.repeat(depth) : './';
   const pageMap = {
     'home': basePath + 'index.html',
     'cadastro-cliente': basePath + 'domains/clientes/index.html',
     'cadastro-orcamento': basePath + 'domains/orcamentos/novo-orcamento.html',
-    'lista-orcamento': basePath + 'domains/orcamentos/lista-orcamento.html'
+    'lista-orcamento': basePath + 'domains/orcamentos/lista-orcamento.html',
+    'orcamento-cliente': basePath + 'domains/orcamentos/orcamento/index.html'
   };
 
   const el = document.getElementById(id);

--- a/styles.css
+++ b/styles.css
@@ -69,7 +69,7 @@ input, select {
 .orcamento-actions {
   display: flex; gap: 8px; margin-top: 9px; flex-wrap: wrap;
 }
-.btn-edit, .btn-delete, .btn-share {
+.btn-edit, .btn-delete, .btn-share, .btn-view {
   border: none; border-radius: 9px; padding: 7px 14px; font-size: 0.98em; cursor: pointer;
   color: #fff; transition: opacity 0.2s; display: flex; align-items: center; gap: 2px;
   font-weight: 500;
@@ -77,7 +77,8 @@ input, select {
 .btn-edit { background: var(--edit);}
 .btn-delete { background: var(--danger);}
 .btn-share { background: var(--success);}
-.btn-edit:active, .btn-delete:active, .btn-share:active { opacity: 0.8;}
+.btn-view { background: var(--primary);}
+.btn-edit:active, .btn-delete:active, .btn-share:active, .btn-view:active { opacity: 0.8;}
 .search-box { margin-bottom: 12px; font-size: 1em;}
 .total-soma {
   margin: 17px 0 11px 0; padding: 10px; background: #f0e7cf; border-radius: var(--radius);


### PR DESCRIPTION
## Summary
- add page to display individual client budget
- enable navigation from budget list to new page
- update global navigation mappings
- style new button
- document new files in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b0e14cfb08322880dccf5f88ce045