### PR TITLE
Add theme management feature

### DIFF
--- a/domains/orcamentos/orcamento/orcamento.js
+++ b/domains/orcamentos/orcamento/orcamento.js
@@ -3,6 +3,18 @@ function obterParametro(nome) {
   return url.searchParams.get(nome);
 }
 
+function aplicarTema() {
+  let tema = null;
+  try {
+    tema = JSON.parse(localStorage.getItem('temaAtual'));
+  } catch (e) {
+    tema = null;
+  }
+  if (tema && tema.cor) {
+    document.documentElement.style.setProperty('--primary', tema.cor);
+  }
+}
+
 function exibirOrcamento() {
   const idx = obterParametro('idx');
   if (idx === null) {
@@ -27,4 +39,7 @@ function exibirOrcamento() {
   `;
 }
 
-document.addEventListener('DOMContentLoaded', exibirOrcamento);
+document.addEventListener('DOMContentLoaded', function() {
+  aplicarTema();
+  exibirOrcamento();
+});

--- a/domains/temas/index.html
+++ b/domains/temas/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Gerenciar Tema - Amigos Móveis Planejados</title>
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="temas.css">
+</head>
+<body>
+  <div class="header">
+    <div class="header-logo capitalize">Amigos Móveis Planejados</div>
+    <div class="header-desc">Gestão fácil de clientes e orçamentos<br>Móveis sob medida com confiança.</div>
+  </div>
+  <div class="container">
+    <div class="card" id="gerenciar-tema">
+      <h2>Gerenciar Tema</h2>
+      <label for="tema-nome">Nome do tema</label>
+      <input type="text" id="tema-nome" placeholder="Nome do tema">
+      <label for="tema-cor">Cor principal</label>
+      <input type="color" id="tema-cor" value="#1e40af">
+      <button class="form-btn" onclick="salvarTema()">Salvar</button>
+      <ul id="lista-temas" style="list-style:none;padding:0;margin-top:10px;"></ul>
+      <button class="form-btn" style="background:#fbbf24;color:#1e293b" onclick="showSection('home')">Voltar ao Menu</button>
+    </div>
+  </div>
+  <script src="../../script.js"></script>
+  <script src="temas.js"></script>
+  <footer style="text-align:center;font-size:.96em;padding:15px 7px 11px 7px;color:#6c584c; background:#f9fafb;">
+    Sistema desenvolvido por <b class="capitalize">João & Bruno</b>
+  </footer>
+</body>
+</html>

--- a/domains/temas/temas.css
+++ b/domains/temas/temas.css
@@ -1,0 +1,7 @@
+#gerenciar-tema {
+  border-left: 4px solid var(--primary);
+  padding-left: 10px;
+}
+.tema-item button {
+  margin-left: 5px;
+}

--- a/domains/temas/temas.js
+++ b/domains/temas/temas.js
@@ -1,0 +1,54 @@
+let temas = [];
+try {
+  temas = JSON.parse(localStorage.getItem('temas')) || [];
+} catch (e) {
+  temas = [];
+}
+let temaEditando = null;
+
+function salvarTema() {
+  const nome = capitalizar(document.getElementById('tema-nome').value);
+  const cor = document.getElementById('tema-cor').value;
+  if (!nome) return;
+  if (temaEditando !== null) {
+    temas[temaEditando] = { nome, cor };
+    temaEditando = null;
+  } else {
+    temas.push({ nome, cor });
+  }
+  localStorage.setItem('temas', JSON.stringify(temas));
+  atualizarListaTemas();
+  document.getElementById('tema-nome').value = '';
+}
+
+function editarTema(idx) {
+  const t = temas[idx];
+  document.getElementById('tema-nome').value = t.nome;
+  document.getElementById('tema-cor').value = t.cor;
+  temaEditando = idx;
+}
+
+function excluirTema(idx) {
+  if (!confirm('Excluir este tema?')) return;
+  temas.splice(idx, 1);
+  localStorage.setItem('temas', JSON.stringify(temas));
+  atualizarListaTemas();
+}
+
+function aplicarTema(idx) {
+  localStorage.setItem('temaAtual', JSON.stringify(temas[idx]));
+  alert('Tema aplicado!');
+}
+
+function atualizarListaTemas() {
+  const ul = document.getElementById('lista-temas');
+  ul.innerHTML = temas.map((t, i) =>
+    `<li class="tema-item">
+       <span style="background:${t.cor};color:#fff;padding:2px 6px;border-radius:4px">${t.nome}</span>
+       <button onclick="editarTema(${i})">Editar</button>
+       <button onclick="excluirTema(${i})">Excluir</button>
+       <button onclick="aplicarTema(${i})">Aplicar</button>
+     </li>`).join('');
+}
+
+document.addEventListener('DOMContentLoaded', atualizarListaTemas);

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         <button onclick="showSection('cadastro-cliente')">Cadastro de cliente</button>
         <button onclick="showSection('cadastro-orcamento')">Novo orçamento</button>
         <button onclick="showSection('lista-orcamento')">Listar orçamentos</button>
+        <button onclick="showSection('gerenciar-tema')">Tema do orçamento</button>
       </div>
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -61,7 +61,8 @@ showSection = function (id) {
     'cadastro-cliente': basePath + 'domains/clientes/index.html',
     'cadastro-orcamento': basePath + 'domains/orcamentos/novo-orcamento.html',
     'lista-orcamento': basePath + 'domains/orcamentos/lista-orcamento.html',
-    'orcamento-cliente': basePath + 'domains/orcamentos/orcamento/index.html'
+    'orcamento-cliente': basePath + 'domains/orcamentos/orcamento/index.html',
+    'gerenciar-tema': basePath + 'domains/temas/index.html'
   };
 
   const el = document.getElementById(id);


### PR DESCRIPTION
## Summary
- add a `gerenciar-tema` option to the main menu
- route new menu entry to `domains/temas/index.html`
- implement Theme CRUD at `domains/temas` (HTML/JS/CSS)
- store selected theme and apply it on the budget page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b1130eeb883228d4f8a168b689454