### PR TITLE
Use Vuetify for alerts and autocomplete

### DIFF
--- a/domains/orcamentos/novo-orcamento.js
+++ b/domains/orcamentos/novo-orcamento.js
@@ -1,40 +1,4 @@
 // Funções para criação e edição de orçamentos
-function filtrarSugestoesCliente() {
-  let busca = document.getElementById('cliente-orcamento-busca').value.toLowerCase().trim();
-  let lista = clientes.map((c,i) => ({
-    idx: i,
-    label: `${c.nome} ${c.sobrenome} - ${c.cpf} - ${c.telefone}`
-  }));
-  if(busca.length > 0) {
-    lista = lista.filter(c => c.label.toLowerCase().includes(busca));
-  }
-  let sugDiv = document.getElementById('sugestoes-clientes');
-  sugDiv.innerHTML = "";
-  if(lista.length === 0 && busca.length > 0) {
-    let n = document.createElement("div");
-    n.textContent = "Nenhum cliente encontrado.";
-    n.style.color = "#aaa";
-    sugDiv.appendChild(n);
-    document.getElementById('cliente-orcamento-indice').value = "";
-    return;
-  }
-  lista.slice(0,10).forEach(cli => {
-    let d = document.createElement("div");
-    d.textContent = cli.label;
-    d.onclick = function(){
-      document.getElementById('cliente-orcamento-busca').value = cli.label;
-      document.getElementById('cliente-orcamento-indice').value = cli.idx;
-      sugDiv.innerHTML = "";
-    };
-    sugDiv.appendChild(d);
-  });
-}
-
-document.addEventListener('click', function(e){
-  if(!e.target.closest('#cliente-orcamento-busca') && !e.target.closest('#sugestoes-clientes')) {
-    document.getElementById('sugestoes-clientes').innerHTML = "";
-  }
-});
 
 function adicionarItem(descricao = "", valor = "") {
   const container = document.getElementById('itens-orcamento');
@@ -81,8 +45,8 @@ function atualizarTotalItens() {
 }
 function salvarOrcamento() {
   if(clientes.length === 0) { showAviso("Cadastre um cliente primeiro!","#ef4444"); return; }
-  const idx = document.getElementById('cliente-orcamento-indice').value;
-  if(idx === "") { showAviso("Escolha o cliente da lista!","#ef4444"); return; }
+  const idx = window.app ? window.app.clienteSelecionado : null;
+  if(idx === null || idx === "") { showAviso("Escolha o cliente da lista!","#ef4444"); return; }
   const clienteObj = clientes[idx];
   let itens = obterItensForm();
   if (itens.length == 0) { showAviso("Adicione ao menos 1 item!","#ef4444"); return; }
@@ -118,16 +82,16 @@ function resetOrcamentoForm() {
   orcamentoEditando = null;
   document.getElementById('btn-inserir-editar').textContent = 'Inserir';
   document.getElementById('orcamento-titulo').textContent = 'Novo orçamento';
+  if (window.app) window.app.clienteSelecionado = null;
 }
 function editarOrcamento(idx) {
   const orc = orcamentos[idx];
   showSection('cadastro-orcamento');
-  document.getElementById('cliente-orcamento-busca').value = `${orc.cliente} - ${orc.cpf} - ${orc.telefone}`;
-  let index = clientes.findIndex(c=>
-    `${c.nome} ${c.sobrenome}`.toLowerCase() === orc.cliente.toLowerCase() && c.cpf === orc.cpf
-  );
-  document.getElementById('cliente-orcamento-indice').value = index >=0 ? index : "";
-  document.getElementById('sugestoes-clientes').innerHTML = "";
+  if (window.app) {
+    window.app.clienteSelecionado = clientes.findIndex(c =>
+      `${c.nome} ${c.sobrenome}`.toLowerCase() === orc.cliente.toLowerCase() && c.cpf === orc.cpf
+    );
+  }
   const itensDiv = document.getElementById('itens-orcamento');
   itensDiv.innerHTML = '';
   orc.itens.forEach(it => adicionarItem(it.descricao, "R$ "+Number(it.valor).toLocaleString('pt-BR', {minimumFractionDigits:2})));
@@ -138,14 +102,10 @@ function editarOrcamento(idx) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  let campo = document.getElementById('cliente-orcamento-busca');
-  if (campo) {
-    campo.addEventListener('touchend', function(){
-      setTimeout(filtrarSugestoesCliente, 80);
-    }, false);
-    campo.addEventListener('focus', function(){
-      setTimeout(filtrarSugestoesCliente, 80);
-    }, false);
-    campo.addEventListener('input', filtrarSugestoesCliente, false);
+  if (window.app) {
+    window.app.clientesOptions = clientes.map((c, i) => ({
+      idx: i,
+      label: `${c.nome} ${c.sobrenome} - ${c.cpf} - ${c.telefone}`
+    }));
   }
 });

--- a/domains/orcamentos/novo-orcamento.js
+++ b/domains/orcamentos/novo-orcamento.js
@@ -46,7 +46,10 @@ function atualizarTotalItens() {
 function salvarOrcamento() {
   if(clientes.length === 0) { showAviso("Cadastre um cliente primeiro!","#ef4444"); return; }
   const idx = window.app ? window.app.clienteSelecionado : null;
-  if(idx === null || idx === "") { showAviso("Escolha o cliente da lista!","#ef4444"); return; }
+  if(idx === null || idx === "" || idx < 0) {
+    showAviso("Escolha o cliente da lista!","#ef4444");
+    return;
+  }
   const clienteObj = clientes[idx];
   let itens = obterItensForm();
   if (itens.length == 0) { showAviso("Adicione ao menos 1 item!","#ef4444"); return; }
@@ -88,9 +91,10 @@ function editarOrcamento(idx) {
   const orc = orcamentos[idx];
   showSection('cadastro-orcamento');
   if (window.app) {
-    window.app.clienteSelecionado = clientes.findIndex(c =>
+    const index = clientes.findIndex(c =>
       `${c.nome} ${c.sobrenome}`.toLowerCase() === orc.cliente.toLowerCase() && c.cpf === orc.cpf
     );
+    window.app.clienteSelecionado = index >= 0 ? index : null;
   }
   const itensDiv = document.getElementById('itens-orcamento');
   itensDiv.innerHTML = '';

--- a/main.js
+++ b/main.js
@@ -97,7 +97,11 @@ const app = createApp({
         </div>
       </div>
     </v-main>
-    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="2100">
+    <v-snackbar
+      v-model="snackbar.show"
+      timeout="2100"
+      :style="{ background: snackbar.color, color: '#fff' }"
+    >
       {{ snackbar.msg }}
     </v-snackbar>
     <footer style="text-align:center;font-size:.96em;padding:15px 7px 11px 7px;color:#6c584c; background:#f9fafb;">

--- a/main.js
+++ b/main.js
@@ -5,7 +5,12 @@ const vuetify = createVuetify();
 
 const app = createApp({
   data() {
-    return { section: 'home' };
+    return {
+      section: 'home',
+      snackbar: { show: false, msg: '', color: 'primary' },
+      clientesOptions: [],
+      clienteSelecionado: null
+    };
   },
   methods: {
     go(sec) { showSection(sec); }
@@ -50,9 +55,16 @@ const app = createApp({
 
         <div class="card" id="cadastro-orcamento" v-show="section === 'cadastro-orcamento'">
           <h2 id="orcamento-titulo">Novo orçamento</h2>
-          <v-text-field label="Cliente" id="cliente-orcamento-busca" placeholder="Pesquisar cliente por nome ou CPF..." autocomplete="off"></v-text-field>
-          <div id="sugestoes-clientes" class="autocomplete-list"></div>
-          <input type="hidden" id="cliente-orcamento-indice">
+          <v-autocomplete
+            id="cliente-orcamento-autocomplete"
+            label="Cliente"
+            :items="clientesOptions"
+            item-title="label"
+            item-value="idx"
+            v-model="clienteSelecionado"
+            placeholder="Pesquisar cliente por nome ou CPF..."
+            autocomplete="off"
+          ></v-autocomplete>
           <div class="itens-orcamento" id="itens-orcamento"></div>
           <div class="itens-lista-total" id="itens-lista-total"></div>
           <v-btn type="button" class="add-item-btn" onclick="adicionarItem()">Adicionar item</v-btn>
@@ -85,6 +97,9 @@ const app = createApp({
         </div>
       </div>
     </v-main>
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="2100">
+      {{ snackbar.msg }}
+    </v-snackbar>
     <footer style="text-align:center;font-size:.96em;padding:15px 7px 11px 7px;color:#6c584c; background:#f9fafb;">
       Sistema desenvolvido por <b class="capitalize">João & Bruno</b>
     </footer>

--- a/script.js
+++ b/script.js
@@ -17,23 +17,15 @@ function capitalizar(str) {
   return str.replace(/\b\w/g, l => l.toUpperCase()).replace(/\s+/g, ' ').trim();
 }
 
-// Função de aviso elegante no topo
+// Exibe aviso via v-snackbar
 function showAviso(msg, cor = "#2563eb") {
-  let aviso = document.getElementById("aviso-msg");
-  if (!aviso) {
-    aviso = document.createElement("div");
-    aviso.id = "aviso-msg";
-    aviso.style = "position:fixed;top:0;left:0;right:0;z-index:99;display:flex;align-items:center;justify-content:center;font-weight:500;font-size:1.08em;background:" + cor + ";color:#fff;padding:13px 7px;box-shadow:0 2px 10px #0001;transition:top .3s; border-radius:0 0 18px 18px;min-height:35px;letter-spacing:.02em;";
-    document.body.prepend(aviso);
+  if (window.app) {
+    window.app.snackbar.msg = msg;
+    window.app.snackbar.color = cor;
+    window.app.snackbar.show = true;
+  } else {
+    alert(msg);
   }
-  aviso.textContent = msg;
-  aviso.style.background = cor;
-  aviso.style.display = "flex";
-  aviso.style.top = "0";
-  setTimeout(() => {
-    aviso.style.top = "-60px";
-    setTimeout(()=>{aviso.style.display="none"},400);
-  }, 2100);
 }
 
 let clientes, orcamentos;
@@ -57,35 +49,28 @@ showSection = function (id) {
 
   if (window.app) window.app.section = id;
 
-  ['home','cadastro-cliente','cadastro-orcamento','lista-orcamento',
-   'orcamento-cliente','gerenciar-termo'].forEach(sec => {
-    const s = document.getElementById(sec);
-    if (s) s.style.display = sec === id ? 'block' : 'none';
-  });
 
   if (id === 'cadastro-cliente') {
     fecharClienteDetalhe();
     atualizarListaClientes();
     setTimeout(() => {
-      let busca = document.getElementById('buscaCliente');
+      const busca = document.getElementById('buscaCliente');
       if (busca) busca.focus();
     }, 200);
   }
   if (id === 'cadastro-orcamento') {
-    document.getElementById('cliente-orcamento-busca').value = '';
-    document.getElementById('cliente-orcamento-indice').value = '';
-    document.getElementById('sugestoes-clientes').innerHTML = '';
-    if (clientes.length === 1) {
-      const unico = clientes[0];
-      document.getElementById('cliente-orcamento-busca').value = `${unico.nome} ${unico.sobrenome} - ${unico.cpf} - ${unico.telefone}`;
-      document.getElementById('cliente-orcamento-indice').value = 0;
+    if (window.app) {
+      window.app.clientesOptions = clientes.map((c, i) => ({
+        idx: i,
+        label: `${c.nome} ${c.sobrenome} - ${c.cpf} - ${c.telefone}`
+      }));
+      window.app.clienteSelecionado = clientes.length === 1 ? 0 : null;
     }
     if (document.getElementById('itens-orcamento').children.length === 0) adicionarItem();
     setTimeout(() => {
-      let busca = document.getElementById('cliente-orcamento-busca');
-      if (busca) busca.focus();
+      const campo = document.querySelector('#cliente-orcamento-autocomplete input');
+      if (campo) campo.focus();
     }, 200);
-    filtrarSugestoesCliente();
   }
   if (id === 'lista-orcamento') {
     atualizarListaOrcamento();


### PR DESCRIPTION
## Summary
- switch manual alerts to a global Vuetify snackbar
- add Vuetify autocomplete for selecting clients
- update section switching logic to fill autocomplete items
- refactor budget creation to use the new selection model

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b3a224a3483228a9b55fc3de3ff60